### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
             verboseMode: true
             testMode: true
             configPath: "vendor/my-company/coding-style/pint.json"
-            pintVersion: 1.2.1
+            pintVersion: 1.8.0
             onlyDirty: true
           
 ```


### PR DESCRIPTION
Fixes the pint version being too low for `--dirty` in the example. 

As seen in https://github.com/aglipanci/laravel-pint-action/pull/5#issuecomment-1474824326, the version of Pint must be at least `1.4.0` to enable the `onlyDirty` argument to work.

This PR bumps the version of pint used in the example `pint.yml`, so if someone uses the example without modifying it, it should work without error.