### PR TITLE
Add a flag to use the local project's version of Laravel Pint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
    
   useComposer:
-    description: "Use Laravel Pint version from project composer lock file."
+    description: "Use Laravel Pint version from project composer lock file. Lock file must be preset to use this flag."
     required: false
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
   pintVersion:
     description: "laravel/pint composer version to install a specific version."
     required: false
+   
+  useComposer:
+    description: "Use Laravel Pint version from project composer lock file."
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -35,6 +39,7 @@ runs:
     - ${{ inputs.preset }}
     - ${{ inputs.only-dirty }}
     - ${{ inputs.pint-version }}
+    - ${{ inputs.use-composer }}
 branding:
   icon: 'eye'  
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,9 @@ pint_install_command=("composer global require laravel/pint:PINT_VERSION --no-pr
 if [[ "${INPUT_PINTVERSION}" ]]
 then
  pint_install_command="${pint_install_command/PINT_VERSION/${INPUT_PINTVERSION}}"
+elif  [[ "${INPUT_USECOMPOSER}" ]]
+then
+ pint_install_command="${pint_install_command/PINT_VERSION/$(composer show --locked | grep 'laravel/pint' | awk '{print $2}')}"
 else
  pint_install_command="${pint_install_command/:PINT_VERSION/}"
 fi


### PR DESCRIPTION
The new flag will tie Laravel/pint to the version saved in the project composer.lock file.