### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ jobs:
   phplint:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v4
         - name: "laravel-pint"
-          uses: aglipanci/laravel-pint-action@2.0.0
+          uses: aglipanci/laravel-pint-action@latest
           with:
             preset: laravel
             verboseMode: true


### PR DESCRIPTION
Now there is **`latest`** tag
[https://github.com/aglipanci/laravel-pint-action/releases/tag/latest](https://github.com/aglipanci/laravel-pint-action/releases/tag/latest)

But there is something strange, **`latest`** points to https://github.com/aglipanci/laravel-pint-action/commit/61f2bc4f4d5da076029d370fa2f268fd6b298041, which is `2.3.1`, when it should point to https://github.com/aglipanci/laravel-pint-action/commit/8eedec46a1856977c41667f9c66d5562fa3f9c08 which is `2.4.0`
So, "**`latest`**" is not the real **`latest`**
Look: https://github.com/aglipanci/laravel-pint-action/tags