### PR TITLE
Pint --diff arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
             configPath: "vendor/my-company/coding-style/pint.json"
             pintVersion: 1.8.0
             onlyDirty: true
-            # onlyDiff: "origin/main"
+            onlyDiff: "main"
           
 ```
 ℹ️ Starting from version 2 you can specify the Pint version to be used by specifying a `pintVersion` in your configuration file.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ GitHub Action implementation of the [Laravel Pint](https://github.com/laravel/pi
 
 Use with [GitHub Actions](https://github.com/features/actions)
 
-_.github/workflows/pint.yml
+`_.github/workflows/pint.yml`
 
-```
+```yml
 name: PHP Linting
 on: pull_request
 jobs:
@@ -25,6 +25,7 @@ jobs:
             configPath: "vendor/my-company/coding-style/pint.json"
             pintVersion: 1.8.0
             onlyDirty: true
+            # onlyDiff: "origin/main"
           
 ```
 ℹ️ Starting from version 2 you can specify the Pint version to be used by specifying a `pintVersion` in your configuration file.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   onlyDirty:
     description: "only format changed files"
     required: false
+
+  onlyDiff:
+    description: "only format changed files that differ from the provided branch"
+    required: false
     
   pintVersion:
     description: "laravel/pint composer version to install a specific version."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,11 @@ if [[ "${INPUT_PRESET}" ]]; then
   pint_command+=" --preset ${INPUT_PRESET}"
 fi
 
+if [[ "${INPUT_ONLYDIFF}" ]]; then
+  pint_command+=" --diff=${INPUT_ONLYDIFF}"
+  INPUT_ONLYDIRTY=false
+fi
+
 if [[ "${INPUT_ONLYDIRTY}" == true ]]; then
   pint_command+=" --dirty"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,18 +31,8 @@ if [[ "${INPUT_PRESET}" ]]; then
   pint_command+=" --preset ${INPUT_PRESET}"
 fi
 
-if [[ "${INPUT_ONLYDIFF}" == true ]]; then
-  if [[ -n "${GITHUB_TOKEN}" ]]; then
-    INPUT_ONLYDIFF=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-      "https://api.github.com/repos/${GITHUB_REPOSITORY}" | jq -r .default_branch)
-  else
-    INPUT_ONLYDIFF=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-  fi
-fi
-
 if [[ "${INPUT_ONLYDIFF}" ]]; then
   pint_command+=" --diff=${INPUT_ONLYDIFF}"
-  INPUT_ONLYDIRTY=false
 fi
 
 if [[ "${INPUT_ONLYDIRTY}" == true ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,15 @@ if [[ "${INPUT_PRESET}" ]]; then
   pint_command+=" --preset ${INPUT_PRESET}"
 fi
 
+if [[ "${INPUT_ONLYDIFF}" == true ]]; then
+  if [[ -n "${GITHUB_TOKEN}" ]]; then
+    INPUT_ONLYDIFF=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "https://api.github.com/repos/${GITHUB_REPOSITORY}" | jq -r .default_branch)
+  else
+    INPUT_ONLYDIFF=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+  fi
+fi
+
 if [[ "${INPUT_ONLYDIFF}" ]]; then
   pint_command+=" --diff=${INPUT_ONLYDIFF}"
   INPUT_ONLYDIRTY=false


### PR DESCRIPTION
- Closes #21

> Laravel Pint [v1.20.0](https://github.com/laravel/pint/releases/tag/v1.20.0) adds a new option --diff described here: https://github.com/laravel/pint/pull/327

>This PR is how I've always wished the --dirty flag worked.
>
>pint --dirty will lint staged and unstaged files (and possibly untracked?). But once a file is committed, it will not be touched again by pint --dirty, whether or not it passes. The only time it will be linted is when we run pint on the whole project again.
>
>This also means that running pint --dirty in CI is pointless, since all the files have already been committed, meaning we'll lint nothing. But running Pint without any flags can take upto five minutes in a large project, and that feedback cycle sucks.
>
>pint --diff=main will collect all committed, staged, unstaged, and untracked files that differ from the provided branch. Meaning that if we've got a PR that only touches 5 files, we can now run pint --diff=main in CI, and we're only going to look at those 5 files, saving a ton of time.
>
>We can also use this effectively locally. If your regular workflow is to create a branch from within a new issue, then check that branch out locally, your main branch might not be up to date with origin. Running pint --diff=main might not give you the results you'd expect then. However using pint --diff=origin/main can help speed up your feedback cycle dramatically.